### PR TITLE
Fix typo `Javascript` -> `JavaScript`

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 ![Demo of Ratatui](https://raw.githubusercontent.com/ratatui/ratatui/aa09e59dc0058347f68d7c1e0c91f863c6f2b8c9/examples/demo2.gif)
 
 `ratatui` is a [Rust](https://www.rust-lang.org) library that's all about cooking up terminal user interfaces (TUIs).
-It is heavily inspired by the `Javascript`
+It is heavily inspired by the `JavaScript`
 library [blessed-contrib](https://github.com/yaronn/blessed-contrib) and the
 `Go` library [termui](https://github.com/gizak/termui).
 


### PR DESCRIPTION
Thanks for maintaining awesome tui library always!

I found and fixed tiny typo.